### PR TITLE
Prompt users before switching GPU profile using asus_gpu_switch

### DIFF
--- a/etc/systemd/system/asusgpuswitch.service
+++ b/etc/systemd/system/asusgpuswitch.service
@@ -4,4 +4,4 @@ Description=ASUS G14 GPU switch script...
 [Service]
 User=root
 Type=simple
-ExecStart=/usr/sbin/asus_gpu_switch
+ExecStart=/usr/sbin/asus_gpu_switch -y

--- a/usr/sbin/asus_gpu_switch
+++ b/usr/sbin/asus_gpu_switch
@@ -3,27 +3,32 @@
 GPUFILE=/etc/asus_nvidia
 
 if [ -f $GPUFILE ]; then
-  echo "$GPUFILE exists."
   GPUFILEPRESENT=true
+  GPUPROFILE="Nvidia"
 else
-  echo "$GPUFILE does not exist."
   GPUFILEPRESENT=false
+  GPUPROFILE="AMD"
 fi
 
-if [[ $GPUFILEPRESENT == false ]]; then
-  echo "set to Nvidia mode flag and restart GDM"
-  systemctl stop gdm
-  echo -n "0000:01:00.0" > /sys/bus/pci/drivers/nvidia/bind
-  cp /etc/asusd/90-nvidia.conf /etc/X11/xorg.conf.d/90-nvidia.conf
-  touch /etc/asus_nvidia
-  asusctl -p normal
-  systemctl restart gdm.service
-else
-  echo "deactivating nvidia"
-  systemctl stop gdm
-  echo -n "0000:01:00.0" > /sys/bus/pci/drivers/nvidia/unbind
-  rm /etc/X11/xorg.conf.d/90-nvidia.conf
-  rm /etc/asus_nvidia
-  asusctl -p silent
-  systemctl restart gdm.service
+echo "Current profile is set to $GPUPROFILE GPU. Do you want to switch? (y/n)"
+read response
+
+if [ "$response" != "${response#[Yy]}" ] ;then
+  if [[ $GPUFILEPRESENT == false ]]; then
+    echo "set to Nvidia mode flag and restart GDM"
+    systemctl stop gdm
+    echo -n "0000:01:00.0" > /sys/bus/pci/drivers/nvidia/bind
+    cp /etc/asusd/90-nvidia.conf /etc/X11/xorg.conf.d/90-nvidia.conf
+    touch /etc/asus_nvidia
+    asusctl -p normal
+    systemctl restart gdm.service
+  else
+    echo "deactivating nvidia"
+    systemctl stop gdm
+    echo -n "0000:01:00.0" > /sys/bus/pci/drivers/nvidia/unbind
+    rm /etc/X11/xorg.conf.d/90-nvidia.conf
+    rm /etc/asus_nvidia
+    asusctl -p silent
+    systemctl restart gdm.service
+  fi
 fi

--- a/usr/sbin/asus_gpu_switch
+++ b/usr/sbin/asus_gpu_switch
@@ -10,8 +10,12 @@ else
   GPUPROFILE="AMD"
 fi
 
-echo "Current profile is set to $GPUPROFILE GPU. Do you want to switch? (y/n)"
-read response
+if [ $1 == "-y" ] ;then
+  response="Y"
+else
+  echo "Current profile is set to $GPUPROFILE GPU. Do you want to switch? (y/N)"
+  read response
+fi
 
 if [ "$response" != "${response#[Yy]}" ] ;then
   if [[ $GPUFILEPRESENT == false ]]; then


### PR DESCRIPTION
While running the `asus_gpu_switch` service, it can be quite confusing for new users to understand what profile they are in and whether they should switch to their desired GPU. Hence this PR adds a prompt before making the switch, telling the user what GPU is currently being used and a simple `y/n` input to determine if the GPU profile should switch or not.